### PR TITLE
Clean README and Links

### DIFF
--- a/Firmware/EL_XBeeWirelessControl/XBee_ELSequencer/XBee_ELSequencer.ino
+++ b/Firmware/EL_XBeeWirelessControl/XBee_ELSequencer/XBee_ELSequencer.ino
@@ -12,8 +12,8 @@ battery, and a XBee Series 1 transceiver.  An XBee Series 2
 can be used but the throughput of the Series 1 is much higher. To
 reduce latency, I recommend using the XBee Series 1. The basic
 configuration of the XBee module with point-to-point configuratin is
-based on Digi's Example tutorial 
-=> http://examples.digi.com/get-started/basic-xbee-802-15-4-chat/ .
+based on Digi's Example tutorial for "Basic XBee 802.15.4 (Series 1) Chat"
+=> https://www.digi.com/blog/xbee/basic-xbee-802-15-4-chat/ .
 Page 5 of the tutorial shows you how to broadcast with
 point-to-multipoint configuration so that multiple EL Sequencers
 can be controlled.

--- a/Firmware/EL_XBeeWirelessControl/XBee_ELSequencer_Controller/XBee_ELSequencer_Controller.ino
+++ b/Firmware/EL_XBeeWirelessControl/XBee_ELSequencer_Controller/XBee_ELSequencer_Controller.ino
@@ -12,8 +12,8 @@ battery, and a XBee Series 1 transceiver. An XBee Series 2
 can be used but the throughput of the Series 1 is much higher. To
 reduce latency, I recommend using the XBee Series 1. The basic
 configuration of the XBee module with point-to-point configuratin is
-based on Digi's Example tutorial
-=> http://examples.digi.com/get-started/basic-xbee-802-15-4-chat/ .
+based on Digi's Example tutorial for "Basic XBee 802.15.4 (Series 1) Chat"
+=> https://www.digi.com/blog/xbee/basic-xbee-802-15-4-chat/ .
 Page 5 of the tutorial shows you how to broadcast with
 point-to-multipoint configuration so that multiple EL Sequencers
 can be controlled.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,3 @@ License Information
 The hardware is released under [Creative Commons Share-alike 3.0](http://creativecommons.org/licenses/by-sa/3.0/).  
 All other code is open source so please feel free to do anything you want with it; 
 you buy me a beer if you use this and we meet someday ([Beerware license](http://en.wikipedia.org/wiki/Beerware)).
-
-test2
-


### PR DESCRIPTION
Removed the "test2" from the description and updated the links since Digi updated their website. I understand that this is the repository for the old EL Sequencer but I am testing to see if I can do a 2nd pull request on the same repository. =)